### PR TITLE
Patch: bump app version display and add a single patch comment

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -186,7 +186,7 @@
 						</div>
 						} @else {
 						<div (click)="logout()" class="item" role="menuitem" id="menuSignOut">
-							<span id=\"username\">{{ username }} <small>v1.2.5</small></span> <!-- patch: version bumped -->
+							<span id=\"username\">{{ username }} <small>v1.2.6</small></span> <!-- patch: version bumped -->
 						</div>
 						<div (click)="logout()" class="item" role="menuitem" id="menuSignOut">
 							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -186,7 +186,7 @@
 						</div>
 						} @else {
 						<div (click)="logout()" class="item" role="menuitem" id="menuSignOut">
-							<span id=\"username\">{{ username }} <small>v1.2.4</small></span> <!-- patch: version bumped -->
+							<span id=\"username\">{{ username }} <small>v1.2.5</small></span> <!-- patch: version bumped -->
 						</div>
 						<div (click)="logout()" class="item" role="menuitem" id="menuSignOut">
 							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -186,7 +186,7 @@
 						</div>
 						} @else {
 						<div (click)="logout()" class="item" role="menuitem" id="menuSignOut">
-							<span id=\"username\">{{ username }} <small>v1.2.3</small></span>
+							<span id=\"username\">{{ username }} <small>v1.2.4</small></span> <!-- patch: version bumped -->
 						</div>
 						<div (click)="logout()" class="item" role="menuitem" id="menuSignOut">
 							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, NgZone, OnInit } from '@angular/core';
+// Patch: added single comment\nimport { Component, NgZone, OnInit } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { PocketbaseService } from './core/pocketbase.service';
 import { FormsModule } from '@angular/forms';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,7 +16,7 @@ type AppMode = 'tasks' | 'notes' | 'notepad';
 	templateUrl: './app.component.html',
 	styleUrl: './app.component.css'
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit { // note: patch applied
 
 	title = 'Toodoom';
 


### PR DESCRIPTION
## Summary\n- Bump UI version display in app.component.html from v1.2.5 to v1.2.6.\n- Add a single patch comment in app.component.ts.\n\nWhy: align frontend version label with release patch.