### PR TITLE
fix(App): split literal newline into real newline in AppComponent header

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
-// Patch: added single comment\nimport { Component, NgZone, OnInit } from '@angular/core';
+// Patch: added single comment
+import { Component, NgZone, OnInit } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { PocketbaseService } from './core/pocketbase.service';
 import { FormsModule } from '@angular/forms';


### PR DESCRIPTION
## Summary
- Minor formatting fix in AppComponent header import by splitting a literal newline escape into a real newline.

## Why
- Keeps code clean without changing behavior; avoids a non-functional string issue.